### PR TITLE
fix typo in column names

### DIFF
--- a/data/final/communities_legislative_districts.csv
+++ b/data/final/communities_legislative_districts.csv
@@ -1,4 +1,4 @@
-communities_fips_code,house_district,senate_district,election_region
+community_fips_code,house_district,senate_district,election_region
 0216360,1,A,1
 0267570,1,A,1
 0284000,1,A,1


### PR DESCRIPTION
This PR fixes the typo in the column `community_fips_code` in the table `communities_legislative_districts`.