### PR TITLE
Ian/aedg 613 fix blank fields in metadata files

### DIFF
--- a/data/final/bulk_fuel/bulk_fuel.json
+++ b/data/final/bulk_fuel/bulk_fuel.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "bulk_fuel",
     "title": "Bulk Fuel Facilities",
     "description": "Inventory of bulk fuel facilities in Alaska.\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/final/bulk_fuel/bulk_fuel.geojson",
             "name": "bulk_fuel",
             "topics": [
                 "Energy",
@@ -24,7 +24,7 @@
                 "road",
                 "community"
             ],
-            "publicationDate": "2026-04-07",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -146,7 +146,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-04-07",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/final/bulk_fuel/bulk_fuel.md
+++ b/data/final/bulk_fuel/bulk_fuel.md
@@ -70,7 +70,7 @@ AEDG uses this list to define canonical community names since, as free text, the
 > 2. Complied community names, locations, and FIPS identifiers for AEDG
 > 
 
-> **2026-04-07**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/final/capacity/capacity.json
+++ b/data/final/capacity/capacity.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "capacity",
     "title": "Yearly Electrical Generation Capacity by Grid",
     "description": "This dataset is the electrical generation capacity, or nameplate capacity, of power plants summed over the grid for the most recent year available. It summarizes the maximum amount of electrical power that could be generated at any given time classified by fuels that would be used to generate it. This is a normalized table intended for internal use within the AEDG database.\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/final/capacity/capacity.csv",
             "name": "capacity",
             "topics": [
                 "Energy"
@@ -27,7 +27,7 @@
                 "Power Cost Equalization (PCE)",
                 "EIA Form 923"
             ],
-            "publicationDate": "2026-02-10",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -109,7 +109,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-02-10",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/final/capacity/capacity.md
+++ b/data/final/capacity/capacity.md
@@ -40,7 +40,7 @@ AEDG uses this dataset as the best available compilation of electrical generatio
 > 2. Extracted a the most recent capacity figures for each unique grid.
 > 
 
-> **2026-02-10**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/final/monthly_generation/monthly_generation.json
+++ b/data/final/monthly_generation/monthly_generation.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "monthly_generation",
     "title": "Monthly Electrical Generation by Grid",
     "description": "This dataset is monthly electrical generation aggregated by grid. It summarizes the amount of electrical power produced for a grid and the fuels that were used to generate it. This is a normalized table intended for internal use within the AEDG database.\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/final/monthly_generation/monthly_generation.csv",
             "name": "monthly_generation",
             "topics": [
                 "Energy"
@@ -27,7 +27,7 @@
                 "Power Cost Equalization (PCE)",
                 "EIA Form 923"
             ],
-            "publicationDate": "2026-02-10",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -117,7 +117,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-02-10",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/final/monthly_generation/monthly_generation.md
+++ b/data/final/monthly_generation/monthly_generation.md
@@ -46,7 +46,7 @@ AEDG uses this dataset as the best available compilation of electrical generatio
 > 2. Extracted the monthly generation timeseries for each unique grid.
 > 
 
-> **2026-02-10**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/final/monthly_sales/monthly_sales.json
+++ b/data/final/monthly_sales/monthly_sales.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "monthly_sales",
     "title": "Monthly Sales Revenue and Customers by Reporting Entity",
     "description": "Monthly sales, revenue, and customer data aggregated by reporting entity. \n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/final/monthly_sales/monthly_sales.csv",
             "name": "monthly_sales",
             "topics": [
                 "Electricity"
@@ -24,7 +24,7 @@
                 "Power Cost Equalization (PCE)",
                 "EIA Form 923"
             ],
-            "publicationDate": "2026-04-06",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -114,7 +114,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-04-06",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/final/monthly_sales/monthly_sales.md
+++ b/data/final/monthly_sales/monthly_sales.md
@@ -63,7 +63,7 @@ AEDG uses this dataset as the best available compilation of electricity sales, i
 > 4. Kwigillingok double counted PCE data in October 2019, averaged values
 > 
 
-> **2026-04-06**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/final/transportation/transportation.json
+++ b/data/final/transportation/transportation.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "transportation",
     "title": "Community Transportation Summary",
     "description": "Summary of the types of transportation available to each community. This is a normalized table intended for internal use within the AEDG database.\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/final/transportation/transportation.csv",
             "name": "transportation",
             "topics": [
                 "Infrastructure"
@@ -28,7 +28,7 @@
                 "dock",
                 "coastal"
             ],
-            "publicationDate": "2026-01-12",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -105,7 +105,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-01-12",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/final/transportation/transportation.md
+++ b/data/final/transportation/transportation.md
@@ -43,7 +43,7 @@ AEDG used to use the ANSI codes in this dataset as an identifier of communities 
 > 2. Joined transportation data with community FIPS codes to create this table
 > 
 
-> **2026-01-12**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/final/yearly_generation/yearly_generation.json
+++ b/data/final/yearly_generation/yearly_generation.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "yearly_generation",
     "title": "Yearly Electrical Generation by Grid",
     "description": "This dataset is yearly electrical generation aggregated by grid. It summarizes the amount of electrical power produced for a grid and the fuels that were used to generate it. This is a normalized table intended for internal use within the AEDG database.\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/final/yearly_generation/yearly_generation.csv",
             "name": "yearly_generation",
             "topics": [
                 "Energy"
@@ -27,7 +27,7 @@
                 "Power Cost Equalization (PCE)",
                 "EIA Form 923"
             ],
-            "publicationDate": "2026-02-10",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -117,7 +117,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-02-10",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/final/yearly_generation/yearly_generation.md
+++ b/data/final/yearly_generation/yearly_generation.md
@@ -45,7 +45,7 @@ AEDG uses this dataset as the best available compilation of electrical generatio
 > 2. Extracted a yearly generation timeseries for each unique grid.
 > 
 
-> **2026-02-10**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/final/yearly_sales/yearly_sales.json
+++ b/data/final/yearly_sales/yearly_sales.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "yearly_sales",
     "title": "Yearly Sales Revenue and Customers by Reporting Entity",
     "description": "Yearly sales, revenue, and customer data aggregated by reporting entity. \n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/final/yearly_sales/yearly_sales.csv",
             "name": "yearly_sales",
             "topics": [
                 "Electricity"
@@ -24,7 +24,7 @@
                 "Power Cost Equalization (PCE)",
                 "EIA Form 923"
             ],
-            "publicationDate": "2026-04-06",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -114,7 +114,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-04-06",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/final/yearly_sales/yearly_sales.md
+++ b/data/final/yearly_sales/yearly_sales.md
@@ -59,7 +59,7 @@ AEDG uses this dataset as the best available compilation of electricity sales, i
 > **2025**: 1. Inside Passage Elec Coop Inc reported to both PCE and EIA in 2020 and 2021. EIA records were dropped.
 > 
 
-> **2026-04-06**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/public/public_capacity/public_capacity.json
+++ b/data/public/public_capacity/public_capacity.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "public_capacity",
     "title": "Yearly Electrical Generation Capacity by Community",
     "description": "This dataset is the electrical generation capacity, or nameplate capacity, of power plants summed over the grid  and associated with every community connected to the grid. It summarizes the maximum amount of electrical power that could be generated for the most recent year available, classified by fuels that would be used to generate it.\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_capacity/public_capacity.csv",
             "name": "public_capacity",
             "topics": [
                 "Energy"
@@ -28,7 +28,7 @@
                 "EIA Form 923",
                 "community"
             ],
-            "publicationDate": "2026-02-10",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -131,7 +131,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-02-10",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/public/public_capacity/public_capacity.md
+++ b/data/public/public_capacity/public_capacity.md
@@ -49,7 +49,7 @@ AEDG uses this dataset as the best available compilation of electrical generatio
 > 2. Extracted a the most recent capacity figures for each unique grid.
 > 
 
-> **2026-02-10**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/public/public_communities/public_communities.json
+++ b/data/public/public_communities/public_communities.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "public_communities",
     "title": "Alaska Energy Data Gateway Communities",
     "description": "List of the communities displayed in the Alaska Energy Data Gateway (AEDG), cross-walked to other regional energy, governmental, and Indigenous organizations.\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_communities/public_communities.csv",
             "name": "public_communities",
             "topics": [
                 "Social",
@@ -26,7 +26,7 @@
                 "grid",
                 "Public Use Microdata Areas (PUMAs)"
             ],
-            "publicationDate": "2026-02-10",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -248,7 +248,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-02-10",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/public/public_communities/public_communities.md
+++ b/data/public/public_communities/public_communities.md
@@ -93,7 +93,7 @@ Heating degree days (HDD), defined in the U.S. as degrees F below 65 multiplied 
 > 3. Used spatial joins to crosswalk AEDG communities with other organizations to create this dataset
 > 
 
-> **2026-02-10**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/public/public_employment/public_employment.json
+++ b/data/public/public_employment/public_employment.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "public_employment",
     "title": "Community Employment",
     "description": "The number of employed residents and the number of unemployment insurance claimants for each community.\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_employment/public_employment.csv",
             "name": "public_employment",
             "topics": [
                 "Social"
@@ -21,7 +21,7 @@
                 "employment",
                 "community"
             ],
-            "publicationDate": "2026-01-12",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -112,7 +112,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-01-12",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/public/public_employment/public_employment.md
+++ b/data/public/public_employment/public_employment.md
@@ -44,7 +44,7 @@ AEDG uses this dataset to provide employment figures for communities. However, t
 > 3. Joined employment data with AEDG communities to create this dataset
 > 
 
-> **2026-01-12**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/public/public_fuel_prices/public_fuel_prices.json
+++ b/data/public/public_fuel_prices/public_fuel_prices.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "public_fuel_prices",
     "title": "Community Fuel Prices",
     "description": "Heating fuel oil and gasoline prices for Alaskan communities are a composite of three distinct datasets.\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_fuel_prices/public_fuel_prices.csv",
             "name": "public_fuel_prices",
             "topics": [
                 "Energy"
@@ -24,7 +24,7 @@
                 "community",
                 "survey"
             ],
-            "publicationDate": "2026-01-12",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -150,7 +150,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-01-12",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/public/public_fuel_prices/public_fuel_prices.md
+++ b/data/public/public_fuel_prices/public_fuel_prices.md
@@ -63,7 +63,7 @@ AEDG uses this dataset to add the economic region spatial polygon to Anchorage g
 > 4. Joined fuel price data with AEDG communities to create this dataset.
 > 
 
-> **2026-01-12**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/public/public_monthly_electric_rates/public_monthly_electric_rates.json
+++ b/data/public/public_monthly_electric_rates/public_monthly_electric_rates.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "public_monthly_electric_rates",
     "title": "Monthly Electricity Rates for Communities",
     "description": "This dataset is electric rates by communities as they are recorded by reporting entities (i.e. utilities).\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_monthly_electric_rates/public_monthly_electric_rates.csv",
             "name": "public_monthly_electric_rates",
             "topics": [
                 "Energy"
@@ -25,7 +25,7 @@
                 "EIA Form 923",
                 "community"
             ],
-            "publicationDate": "2026-04-08",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -135,7 +135,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-04-08",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/public/public_monthly_electric_rates/public_monthly_electric_rates.md
+++ b/data/public/public_monthly_electric_rates/public_monthly_electric_rates.md
@@ -61,7 +61,7 @@ AEDG uses this dataset as the best available compilation of electricity sales, i
 > 5. Joined rate data with AEDG communities to create this dataset
 > 
 
-> **2026-04-08**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/public/public_monthly_generation/public_monthly_generation.json
+++ b/data/public/public_monthly_generation/public_monthly_generation.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "public_monthly_generation",
     "title": "Monthly Electrical Generation by Community",
     "description": "This dataset is monthly electrical generation aggregated by grid and associated with every community connected to the grid. It summarizes the amount of electrical power produced for a community and the fuels that were used to generate it.\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_monthly_generation/public_monthly_generation.csv",
             "name": "public_monthly_generation",
             "topics": [
                 "Energy"
@@ -28,7 +28,7 @@
                 "EIA Form 923",
                 "community"
             ],
-            "publicationDate": "2026-02-10",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -139,7 +139,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-02-10",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/public/public_monthly_generation/public_monthly_generation.md
+++ b/data/public/public_monthly_generation/public_monthly_generation.md
@@ -54,7 +54,7 @@ AEDG uses this dataset as the best available compilation of electrical generatio
 > 3. Joined generation data with AEDG communities to create this dataset
 > 
 
-> **2026-02-10**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/public/public_populations_ages_sexes/public_populations_ages_sexes.json
+++ b/data/public/public_populations_ages_sexes/public_populations_ages_sexes.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "public_populations_ages_sexes",
     "title": "American Community Survey Populations",
     "description": "Summary of the total population of each community with categorizations by age and sex.\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_populations_ages_sexes/public_populations_ages_sexes.csv",
             "name": "public_populations_ages_sexes",
             "topics": [
                 "Social"
@@ -25,7 +25,7 @@
                 "survey",
                 "census"
             ],
-            "publicationDate": "2026-04-07",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -139,7 +139,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-04-07",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/public/public_populations_ages_sexes/public_populations_ages_sexes.md
+++ b/data/public/public_populations_ages_sexes/public_populations_ages_sexes.md
@@ -71,7 +71,7 @@ AEDG uses this dataset to associate places (point locations) with population div
 > 3. Joined population data with AEDG communities to create this dataset
 > 
 
-> **2026-04-07**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/public/public_taxes/public_taxes.json
+++ b/data/public/public_taxes/public_taxes.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "public_taxes",
     "title": "Taxes for Communities and Boroughs",
     "description": "Sales, property, and special tax revenue for communities and boroughs.\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_taxes/public_taxes.csv",
             "name": "public_taxes",
             "topics": [
                 "Social"
@@ -24,7 +24,7 @@
                 "property",
                 "economy"
             ],
-            "publicationDate": "2026-01-12",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -115,7 +115,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-01-12",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/public/public_taxes/public_taxes.md
+++ b/data/public/public_taxes/public_taxes.md
@@ -48,7 +48,7 @@ AEDG includes tax data as a measure of economic activity. From our analysis, thi
 > 3. Joined tax data with AEDG communities to create this dataset
 > 
 
-> **2026-01-12**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/public/public_transportation/public_transportation.json
+++ b/data/public/public_transportation/public_transportation.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "public_transportation",
     "title": "Community Transportation Summary",
     "description": "Summary of the types of transportation available to each community.\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_transportation/public_transportation.csv",
             "name": "public_transportation",
             "topics": [
                 "Infrastructure"
@@ -28,7 +28,7 @@
                 "dock",
                 "coastal"
             ],
-            "publicationDate": "2026-01-12",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -109,7 +109,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-01-12",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/public/public_transportation/public_transportation.md
+++ b/data/public/public_transportation/public_transportation.md
@@ -49,7 +49,7 @@ AEDG uses these data to display transportation options because these greatly inf
 > 3. Joined transportation data with AEDG communities to create this dataset
 > 
 
-> **2026-01-12**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/public/public_yearly_electric_rates/public_yearly_electric_rates.json
+++ b/data/public/public_yearly_electric_rates/public_yearly_electric_rates.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "public_yearly_electric_rates",
     "title": "Yearly Electricity Rates for Communities",
     "description": "This dataset is electric rates by communities as they are recorded by reporting entities (i.e. utilities).\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_yearly_electric_rates/public_yearly_electric_rates.csv",
             "name": "public_yearly_electric_rates",
             "topics": [
                 "Energy"
@@ -25,7 +25,7 @@
                 "EIA Form 923",
                 "community"
             ],
-            "publicationDate": "2026-04-08",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -156,7 +156,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-04-08",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/public/public_yearly_electric_rates/public_yearly_electric_rates.md
+++ b/data/public/public_yearly_electric_rates/public_yearly_electric_rates.md
@@ -66,7 +66,7 @@ AEDG uses this dataset as the best available compilation of electricity sales, i
 > 5. Joined rate data with AEDG communities to create this dataset
 > 
 
-> **2026-04-08**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/data/public/public_yearly_generation/public_yearly_generation.json
+++ b/data/public/public_yearly_generation/public_yearly_generation.json
@@ -1,12 +1,12 @@
 {
-    "@context": "",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
     "name": "public_yearly_generation",
     "title": "Yearly Electrical Generation by Community",
     "description": "This dataset is yearly electrical generation aggregated by grid and associated with every community connected to the grid. It summarizes the amount of electrical power produced for a community and the fuels that were used to generate it.\n",
-    "@id": "",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
     "resources": [
         {
-            "@id": "",
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_yearly_generation/public_yearly_generation.csv",
             "name": "public_yearly_generation",
             "topics": [
                 "Energy"
@@ -28,7 +28,7 @@
                 "EIA Form 923",
                 "community"
             ],
-            "publicationDate": "2026-02-10",
+            "publicationDate": "2026",
             "context": {
                 "title": "Alaska Energy Data Gateway v3.0",
                 "homepage": "https://akenergygateway.alaska.edu/",
@@ -139,7 +139,7 @@
                     "roles": [
                         "DataCurator"
                     ],
-                    "date": "2026-02-10",
+                    "date": "2026",
                     "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
                     "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
                     "path": "https://www.uaf.edu/acep/"

--- a/data/public/public_yearly_generation/public_yearly_generation.md
+++ b/data/public/public_yearly_generation/public_yearly_generation.md
@@ -50,7 +50,7 @@ AEDG uses this dataset as the best available compilation of electrical generatio
 > 3. Joined generation data with AEDG communities to create this dataset
 > 
 
-> **2026-02-10**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
 > 
 
 ## License

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aedg_metadata @ git+https://github.com/acep-aedg/aedg-metadata.git@24bb7156256d214d01fe8011ebf2c924fdb88e2a
+aedg_metadata @ git+https://github.com/acep-aedg/aedg-metadata.git@v0.2.1
 attrs==25.4.0
 certifi==2025.11.12
 click==8.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,9 @@ markdown-it-py==4.0.0
 mdurl==0.1.2
 numpy==2.3.5
 oemetadata==2.0.4
-packaging==25.0
+packaging==26.0
 pandas==2.3.3
-Pygments==2.19.2
+Pygments==2.20.0
 pyogrio==0.12.1
 pyproj==3.7.2
 python-dateutil==2.9.0.post0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aedg_metadata @ git+https://github.com/acep-aedg/aedg-metadata.git@v0.2.1
+aedg_metadata @ git+https://github.com/acep-aedg/aedg-metadata.git@v0.2.2
 attrs==25.4.0
 certifi==2025.11.12
 click==8.3.1


### PR DESCRIPTION
This PR satisfies

https://projects.camio.acep.uaf.edu/cyberinfrastructure/browse/AEDG-631/
and 
https://projects.camio.acep.uaf.edu/cyberinfrastructure/browse/AEDG-714/

Changes:
- blank fields were populated
   - @context hardcoded with link to OEMetadata's context.json file
   - @id hardcoded to base URL of the data-pond repo
   - resource.@id set as resources.path from the YML config
- `publicationDate` was truncated to year
   - prevents awful git tracking (where every run regenerates)