### PR TITLE
AEDG-795: Create public_household_income metadata

### DIFF
--- a/data/public/public_household_income/public_household_income.json
+++ b/data/public/public_household_income/public_household_income.json
@@ -21,7 +21,8 @@
                 "community",
                 "income",
                 "census",
-                "economy"
+                "economy",
+                "population"
             ],
             "publicationDate": "2026",
             "context": {

--- a/data/public/public_household_income/public_household_income.json
+++ b/data/public/public_household_income/public_household_income.json
@@ -1,0 +1,283 @@
+{
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
+    "name": "public_household_income",
+    "title": "Household Income by Community",
+    "description": "Household counts, median income, and income bracket distributions for communities in Alaska derived from U.S. Census Bureau ACS 5-year estimates.\n",
+    "@id": "https://github.com/acep-aedg/aedg-data-pond",
+    "resources": [
+        {
+            "@id": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_household_income/public_household_income.csv",
+            "name": "public_household_income",
+            "topics": [
+                "Social"
+            ],
+            "title": "Household Income by Community",
+            "path": "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_household_income/public_household_income.csv",
+            "description": "This dataset contains community-level household income and benefits estimates for Alaska derived from U.S. Census Bureau American Community Survey (ACS) 5-year data. It provides total household counts, median household income, and household distributions across income brackets ranging from under $10,000 to $200,000 or more. All income categories and monetary metrics include both household income and benefits, inflation-adjusted to the period end year and are organized by FIPS code, community name, and ACS survey time period.\n",
+            "languages": [
+                "en-US"
+            ],
+            "keywords": [
+                "community",
+                "income",
+                "census",
+                "economy"
+            ],
+            "publicationDate": "2026",
+            "context": {
+                "title": "Alaska Energy Data Gateway v3.0",
+                "homepage": "https://akenergygateway.alaska.edu/",
+                "publisher": "Alaska Center for Energy and Power (ACEP) at the University of Alaska Fairbanks (UAF)",
+                "fundingAgency": "State of Alaska"
+            },
+            "spatial": {
+                "extent": {
+                    "name": "Alaska",
+                    "boundingBox": [
+                        -187.55,
+                        51.21,
+                        -130.0,
+                        71.35
+                    ],
+                    "crs": "OGC:CRS84"
+                }
+            },
+            "temporal": {
+                "referenceDate": "2023",
+                "timeseries": [
+                    {
+                        "start": "2007",
+                        "end": "2023",
+                        "resolutionValue": "5",
+                        "resolutionUnit": "year",
+                        "alignment": "end",
+                        "aggregationType": "average"
+                    }
+                ]
+            },
+            "sources": [
+                {
+                    "title": "Alaska Communities",
+                    "authors": [
+                        "Alaska Division of Community and Regional Affairs (DCRA)"
+                    ],
+                    "description": "The Alaska Communities dataset is the reference list of place locations, represented as points, used by the Alaska Division of Community and Regional Affairs (DCRA). In includes community locations but for historical reasons, it is a mix of Communities, Places of Interest, Borough/Census Area as well as Alaska centroid. DCRA uses it to link communities to their internal key GUID used elsewhere in their systems.\nAEDG uses this list to define canonical community names since, as free text, these can vary in different contexts, and to establish locations to use in spatial joins and relations.\n",
+                    "publicationYear": "2023",
+                    "path": "https://maps.commerce.alaska.gov/server/rest/services/Community_Related/Community_Locations_and_Boundaries/MapServer/0",
+                    "sourceLicenses": []
+                },
+                {
+                    "title": "Places (Cities and CDPs) Shapefile",
+                    "authors": [
+                        "United States Census Bureau",
+                        "Alaska Department of Labor and Workforce Development (DOLWD)"
+                    ],
+                    "description": "This is an ESRI Shapefile for use in GIS software that contains place data from the 2020 US Census for Alaska. The definition of places includes all incorporated cities as well as Census Designated Places (CDPs). Each geographic unit is identified using Federal Information Processing Standards (FIPS) numbers. Coordinate System: North American Datum 1983 Alaska Albers. Source: 2020 US Census, PL94-171 Redistricting File; 2020 US Census Tiger Shapefiles. Documentation of field names: https://live.laborstats.alaska.gov/cen/maps/gis/Places2020.pdf. The Alaska Department of Labor and Workforce Development has had a cooperative agreement with the U.S. Census Bureau since 1981 to assist with geographic programs and help Alaskans find Census Bureau data.\nAEDG uses this list to define canonical community locations to use in spatial joins and relations, to associate places with FIPS codes, and to establish total community population.\n",
+                    "publicationYear": "2020",
+                    "path": "https://live.laborstats.alaska.gov/article/maps-gis-data",
+                    "sourceLicenses": []
+                },
+                {
+                    "title": "American Community Survey Household Income and Benefits",
+                    "authors": [
+                        "United States Census Bureau",
+                        "Alaska Division of Community and Regional Affairs (DCRA)"
+                    ],
+                    "description": "Population counts by household income in Alaskan communities for the last 12 months of the most recent ACS 5-year interval. This data has been visualized in a Geographic Information Systems (GIS) format and is provided as a service in the DCRA Information Portal by the Alaska Department of Commerce, Community, and Economic Development Division of Community and Regional Affairs (SOA DCCED DCRA), Research and Analysis section. SOA DCCED DCRA Research and Analysis is not the authoritative source for this data. For more information and for questions about this data, see: US Census Bureau, Household Income and Alaska American Community Survey Data\n",
+                    "publicationYear": "2025",
+                    "path": "https://maps.commerce.alaska.gov/server/rest/services/Demographics/Alaska_American_Community_Survey/MapServer/3",
+                    "sourceLicenses": [
+                        {
+                            "name": "public-domain",
+                            "title": "U.S. Public Domain",
+                            "path": "http://www.usa.gov/publicdomain/label/1.0/",
+                            "instruction": "Data and content created by government employees within the scope of their employment are not subject\nto domestic copyright protection under 17 U.S.C. \u00a7 105. Government works are by default in the U.S.\nPublic Domain. You cannot use government materials in a way that implies endorsement by a government agency, official, or employee. You also cannot use federal government trademarks or federal government agency logos without permission - https://resources.data.gov/open-licenses/.\n"
+                        }
+                    ]
+                }
+            ],
+            "licenses": [
+                {
+                    "name": "CC-BY-4.0",
+                    "title": "Creative Commons Attribution 4.0 International",
+                    "path": "https://creativecommons.org/licenses/by/4.0/",
+                    "instruction": "You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use. You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.\n",
+                    "attribution": "Alaska Center for Energy and Power, University of Alaska Fairbanks"
+                }
+            ],
+            "contributors": [
+                {
+                    "organization": "Alaska Center for Energy and Power (ACEP) at the University of Alaska Fairbanks (UAF)",
+                    "roles": [
+                        "DataCurator"
+                    ],
+                    "date": "2025",
+                    "object": "data via https://github.com/acep-aedg/aedg-etl-2024",
+                    "comment": "1. Identified data source and integrated it into the data pipeline.\n2. Complied community names, locations, and FIPS identifiers for AEDG\n3. Joined household_income data with AEDG communities to create this dataset\n",
+                    "path": "https://www.uaf.edu/acep/"
+                },
+                {
+                    "organization": "Alaska Center for Energy and Power (ACEP) at the University of Alaska Fairbanks (UAF)",
+                    "roles": [
+                        "DataCurator"
+                    ],
+                    "date": "2026",
+                    "object": "metadata via https://github.com/acep-aedg/aedg-metadata",
+                    "comment": "Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.\n",
+                    "path": "https://www.uaf.edu/acep/"
+                }
+            ],
+            "type": "table",
+            "format": "csv",
+            "encoding": "",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "fips_code",
+                        "long_name": "FIPS Code",
+                        "description": "5-digit Federal Information Processing Series (FIPS) code identifier for places and boroughs (counties), assigned and maintained by the Census Bureau",
+                        "type": "string",
+                        "nullable": false,
+                        "unit": null
+                    },
+                    {
+                        "name": "community_name",
+                        "long_name": "Community Name",
+                        "description": "Name of the community",
+                        "type": "string",
+                        "nullable": false,
+                        "unit": null
+                    },
+                    {
+                        "name": "e_households_total",
+                        "long_name": "Total Households",
+                        "description": "Estimated total number of households",
+                        "type": "integer",
+                        "nullable": false,
+                        "unit": "households"
+                    },
+                    {
+                        "name": "e_household_median_income",
+                        "long_name": "Median Household Income",
+                        "description": "Estimated median household income (including benefits, adjusted for inflation to survey end year)",
+                        "type": "integer",
+                        "nullable": true,
+                        "unit": "USD"
+                    },
+                    {
+                        "name": "e_household_inc_under_10000",
+                        "long_name": "Household Income Under $10k",
+                        "description": "Estimated households with income under $10,000 (including benefits, adjusted for inflation to survey end year)",
+                        "type": "integer",
+                        "nullable": false,
+                        "unit": "households"
+                    },
+                    {
+                        "name": "e_household_inc_10000_14999",
+                        "long_name": "Household Income $10,000\u2013$14,999",
+                        "description": "Estimated households with income of $10,000 to $14,999 (including benefits, adjusted for inflation to survey end year)",
+                        "type": "integer",
+                        "nullable": false,
+                        "unit": "households"
+                    },
+                    {
+                        "name": "e_household_inc_15000_24999",
+                        "long_name": "Household Income $15,000\u2013$24,999",
+                        "description": "Estimated households with income of $15,000 to $24,999 (including benefits, adjusted for inflation to survey end year)",
+                        "type": "integer",
+                        "nullable": false,
+                        "unit": "households"
+                    },
+                    {
+                        "name": "e_household_inc_25000_34999",
+                        "long_name": "Household Income $25,000\u2013$34,999",
+                        "description": "Estimated households with income of $25,000 to $34,999 (including benefits, adjusted for inflation to survey end year)",
+                        "type": "integer",
+                        "nullable": false,
+                        "unit": "households"
+                    },
+                    {
+                        "name": "e_household_inc_35000_49999",
+                        "long_name": "Household Income $35,000\u2013$49,999",
+                        "description": "Estimated households with income of $35,000 to $49,999 (including benefits, adjusted for inflation to survey end year)",
+                        "type": "integer",
+                        "nullable": false,
+                        "unit": "households"
+                    },
+                    {
+                        "name": "e_household_inc_50000_74999",
+                        "long_name": "Household Income $50,000\u2013$74,999",
+                        "description": "Estimated households with income of $50,000 to $74,999 (including benefits, adjusted for inflation to survey end year)",
+                        "type": "integer",
+                        "nullable": false,
+                        "unit": "households"
+                    },
+                    {
+                        "name": "e_household_inc_75000_99999",
+                        "long_name": "Household Income $75,000\u2013$99,999",
+                        "description": "Estimated households with income of $75,000 to $99,999 (including benefits, adjusted for inflation to survey end year)",
+                        "type": "integer",
+                        "nullable": false,
+                        "unit": "households"
+                    },
+                    {
+                        "name": "e_household_inc_100000_149999",
+                        "long_name": "Household Income $100,000\u2013$149,999",
+                        "description": "Estimated households with income of $100,000 to $149,999 (including benefits, adjusted for inflation to survey end year)",
+                        "type": "integer",
+                        "nullable": false,
+                        "unit": "households"
+                    },
+                    {
+                        "name": "e_household_inc_150000_199999",
+                        "long_name": "Household Income $150,000\u2013$199,999",
+                        "description": "Estimated households with income of $150,000 to $199,999 (including benefits, adjusted for inflation to survey end year)",
+                        "type": "integer",
+                        "nullable": false,
+                        "unit": "households"
+                    },
+                    {
+                        "name": "e_household_inc_200000_plus",
+                        "long_name": "Household Income $200,000+",
+                        "description": "Estimated households with income of $200,000 or more (including benefits, adjusted for inflation to survey end year)",
+                        "type": "integer",
+                        "nullable": false,
+                        "unit": "households"
+                    },
+                    {
+                        "name": "start_year",
+                        "long_name": "ACS Start Year",
+                        "description": "Start year of the 5-year ACS survey observation window",
+                        "type": "integer",
+                        "nullable": false,
+                        "unit": "year"
+                    },
+                    {
+                        "name": "end_year",
+                        "long_name": "ACS End Year",
+                        "description": "End year (vintage) of the 5-year ACS survey observation window",
+                        "type": "integer",
+                        "nullable": false,
+                        "unit": "year"
+                    }
+                ],
+                "primaryKey": [
+                    "fips_code",
+                    "end_year"
+                ]
+            },
+            "dialect": {
+                "delimiter": ",",
+                "decimalSeparator": "."
+            }
+        }
+    ],
+    "metaMetadata": {
+        "metadataVersion": "OEMetadata-2.0.4",
+        "metadataLicense": {
+            "name": "CC0-1.0",
+            "title": "Creative Commons Zero v1.0 Universal",
+            "path": "https://creativecommons.org/publicdomain/zero/1.0"
+        }
+    }
+}

--- a/data/public/public_household_income/public_household_income.md
+++ b/data/public/public_household_income/public_household_income.md
@@ -1,0 +1,64 @@
+# Household Income by Community
+
+## Description
+This dataset contains community-level household income and benefits estimates for Alaska derived from U.S. Census Bureau American Community Survey (ACS) 5-year data. It provides total household counts, median household income, and household distributions across income brackets ranging from under $10,000 to $200,000 or more. All income categories and monetary metrics include both household income and benefits, inflation-adjusted to the period end year and are organized by FIPS code, community name, and ACS survey time period.
+
+
+## Responsible Party
+* **Publisher:** Alaska Center for Energy and Power (ACEP) at the University of Alaska Fairbanks (UAF)
+* **Funding Agency:** State of Alaska
+
+## Data Lineage
+* **URL:** [https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_household_income/public_household_income.csv](https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_household_income/public_household_income.csv)
+* **Reference Date:** 2023
+
+### Sources
+* **Alaska Communities** (2023)
+  https://maps.commerce.alaska.gov/server/rest/services/Community_Related/Community_Locations_and_Boundaries/MapServer/0
+ The Alaska Communities dataset is the reference list of place locations, represented as points, used by the Alaska Division of Community and Regional Affairs (DCRA). In includes community locations but for historical reasons, it is a mix of Communities, Places of Interest, Borough/Census Area as well as Alaska centroid. DCRA uses it to link communities to their internal key GUID used elsewhere in their systems.
+AEDG uses this list to define canonical community names since, as free text, these can vary in different contexts, and to establish locations to use in spatial joins and relations.
+
+* **Places (Cities and CDPs) Shapefile** (2020)
+  https://live.laborstats.alaska.gov/article/maps-gis-data
+ This is an ESRI Shapefile for use in GIS software that contains place data from the 2020 US Census for Alaska. The definition of places includes all incorporated cities as well as Census Designated Places (CDPs). Each geographic unit is identified using Federal Information Processing Standards (FIPS) numbers. Coordinate System: North American Datum 1983 Alaska Albers. Source: 2020 US Census, PL94-171 Redistricting File; 2020 US Census Tiger Shapefiles. Documentation of field names: https://live.laborstats.alaska.gov/cen/maps/gis/Places2020.pdf. The Alaska Department of Labor and Workforce Development has had a cooperative agreement with the U.S. Census Bureau since 1981 to assist with geographic programs and help Alaskans find Census Bureau data.
+AEDG uses this list to define canonical community locations to use in spatial joins and relations, to associate places with FIPS codes, and to establish total community population.
+
+* **American Community Survey Household Income and Benefits** (2025)
+  https://maps.commerce.alaska.gov/server/rest/services/Demographics/Alaska_American_Community_Survey/MapServer/3
+ Population counts by household income in Alaskan communities for the last 12 months of the most recent ACS 5-year interval. This data has been visualized in a Geographic Information Systems (GIS) format and is provided as a service in the DCRA Information Portal by the Alaska Department of Commerce, Community, and Economic Development Division of Community and Regional Affairs (SOA DCCED DCRA), Research and Analysis section. SOA DCCED DCRA Research and Analysis is not the authoritative source for this data. For more information and for questions about this data, see: US Census Bureau, Household Income and Alaska American Community Survey Data
+
+
+### Data Dictionary
+| Column Name | Type | Unit | Description |
+| :--- | :--- | :--- | :--- |
+| FIPS Code | string | None | 5-digit Federal Information Processing Series (FIPS) code identifier for places and boroughs (counties), assigned and maintained by the Census Bureau |
+| Community Name | string | None | Name of the community |
+| Total Households | integer | households | Estimated total number of households |
+| Median Household Income | integer | USD | Estimated median household income (including benefits, adjusted for inflation to survey end year) |
+| Household Income Under $10k | integer | households | Estimated households with income under $10,000 (including benefits, adjusted for inflation to survey end year) |
+| Household Income $10,000–$14,999 | integer | households | Estimated households with income of $10,000 to $14,999 (including benefits, adjusted for inflation to survey end year) |
+| Household Income $15,000–$24,999 | integer | households | Estimated households with income of $15,000 to $24,999 (including benefits, adjusted for inflation to survey end year) |
+| Household Income $25,000–$34,999 | integer | households | Estimated households with income of $25,000 to $34,999 (including benefits, adjusted for inflation to survey end year) |
+| Household Income $35,000–$49,999 | integer | households | Estimated households with income of $35,000 to $49,999 (including benefits, adjusted for inflation to survey end year) |
+| Household Income $50,000–$74,999 | integer | households | Estimated households with income of $50,000 to $74,999 (including benefits, adjusted for inflation to survey end year) |
+| Household Income $75,000–$99,999 | integer | households | Estimated households with income of $75,000 to $99,999 (including benefits, adjusted for inflation to survey end year) |
+| Household Income $100,000–$149,999 | integer | households | Estimated households with income of $100,000 to $149,999 (including benefits, adjusted for inflation to survey end year) |
+| Household Income $150,000–$199,999 | integer | households | Estimated households with income of $150,000 to $199,999 (including benefits, adjusted for inflation to survey end year) |
+| Household Income $200,000+ | integer | households | Estimated households with income of $200,000 or more (including benefits, adjusted for inflation to survey end year) |
+| ACS Start Year | integer | year | Start year of the 5-year ACS survey observation window |
+| ACS End Year | integer | year | End year (vintage) of the 5-year ACS survey observation window |
+
+### Comments
+> **2025**: 1. Identified data source and integrated it into the data pipeline.
+> 2. Complied community names, locations, and FIPS identifiers for AEDG
+> 3. Joined household_income data with AEDG communities to create this dataset
+> 
+
+> **2026**: Documented sources and defined the data dictionary using OEMetadata (Frictionless) formatted metadata https://doi.org/10.5281/zenodo.15019561.
+> 
+
+## License
+CC-BY-4.0
+Creative Commons Attribution 4.0 International
+https://creativecommons.org/licenses/by/4.0/
+

--- a/data/public/public_household_income/public_household_income.yml
+++ b/data/public/public_household_income/public_household_income.yml
@@ -1,0 +1,48 @@
+resource:
+  name: public_household_income
+  title: Household Income by Community
+  summary: |
+    Household counts, median income, and income bracket distributions for communities in Alaska derived from U.S. Census Bureau ACS 5-year estimates.
+  description: | # Description of what this dataset is and what it is doing here
+    This dataset contains community-level household income and benefits estimates for Alaska derived from U.S. Census Bureau American Community Survey (ACS) 5-year data. It provides total household counts, median household income, and household distributions across income brackets ranging from under $10,000 to $200,000 or more. All income categories and monetary metrics include both household income and benefits, inflation-adjusted to the period end year and are organized by FIPS code, community name, and ACS survey time period.
+  path: "https://raw.githubusercontent.com/acep-aedg/aedg-data-pond/refs/heads/main/data/public/public_household_income/public_household_income.csv" # link to dataset in GitHub
+  keywords:
+    - community
+    - income
+    - census
+    - economy
+  topics:
+    - Social
+  publisher: acep
+  sources: # list of directory names in https://github.com/acep-aedg/aedg-etl-2024/tree/main/data-sources to get source.yml
+    - dcra.communities
+    - dol.places
+    - acs.household_income
+  licenses: # list of keys in the license.yml registry
+    - CC-BY-4.0
+  spatial:
+    name: Alaska
+    boundingBox: [-187.55, 51.21, -130.0, 71.35]
+    crs: OGC:CRS84
+  temporal:
+    referenceDate: "2023"  # equivalent to as_of_date
+    timeseries:
+      - start: "2007"
+        end: "2023"
+        resolutionValue: "5"
+        resolutionUnit: year
+        alignment: end
+        aggregationType: average
+  primaryKey:
+    - fips_code
+    - end_year
+  contributors:
+    - organization: acep
+      roles:
+        - DataCurator
+      date: 2025
+      object: data via https://github.com/acep-aedg/aedg-etl-2024
+      comment: |
+        1. Identified data source and integrated it into the data pipeline.
+        2. Complied community names, locations, and FIPS identifiers for AEDG
+        3. Joined household_income data with AEDG communities to create this dataset

--- a/data/public/public_household_income/public_household_income.yml
+++ b/data/public/public_household_income/public_household_income.yml
@@ -11,6 +11,7 @@ resource:
     - income
     - census
     - economy
+    - population
   topics:
     - Social
   publisher: acep

--- a/registry/active_keywords.csv
+++ b/registry/active_keywords.csv
@@ -23,6 +23,7 @@ keyword,heating fuel
 keyword,income
 keyword,native corporation
 keyword,population conditions
+keyword,population
 keyword,power plant
 keyword,property
 keyword,puma

--- a/registry/active_keywords.csv
+++ b/registry/active_keywords.csv
@@ -20,6 +20,7 @@ keyword,generation
 keyword,grid
 keyword,harbor
 keyword,heating fuel
+keyword,income
 keyword,native corporation
 keyword,population conditions
 keyword,power plant

--- a/registry/fields.csv
+++ b/registry/fields.csv
@@ -28,8 +28,21 @@ description,Description,Narrative description,string,TRUE,null,default
 did_community_report,Community Report,"Answers the question: Did the community report these taxes?  (""t"" for yes, and ""f"" for no)",boolean,TRUE,USD,default
 diesel_capacity,Diesel Capacity,Capacity of diesel in gallons,number,TRUE,gallons,default
 distance_to_barge_mooring,Distance to Barge Mooring,,number,TRUE,NULL,default
+e_household_inc_100000_149999,"Household Income $100,000–$149,999","Estimated households with income of $100,000 to $149,999 (including benefits, adjusted for inflation to survey end year)",integer,false,households,public_household_income.csv
+e_household_inc_10000_14999,"Household Income $10,000–$14,999","Estimated households with income of $10,000 to $14,999 (including benefits, adjusted for inflation to survey end year)",integer,false,households,public_household_income.csv
+e_household_inc_150000_199999,"Household Income $150,000–$199,999","Estimated households with income of $150,000 to $199,999 (including benefits, adjusted for inflation to survey end year)",integer,false,households,public_household_income.csv
+e_household_inc_15000_24999,"Household Income $15,000–$24,999","Estimated households with income of $15,000 to $24,999 (including benefits, adjusted for inflation to survey end year)",integer,false,households,public_household_income.csv
+e_household_inc_200000_plus,"Household Income $200,000+","Estimated households with income of $200,000 or more (including benefits, adjusted for inflation to survey end year)",integer,false,households,public_household_income.csv
+e_household_inc_25000_34999,"Household Income $25,000–$34,999","Estimated households with income of $25,000 to $34,999 (including benefits, adjusted for inflation to survey end year)",integer,false,households,public_household_income.csv
+e_household_inc_35000_49999,"Household Income $35,000–$49,999","Estimated households with income of $35,000 to $49,999 (including benefits, adjusted for inflation to survey end year)",integer,false,households,public_household_income.csv
+e_household_inc_50000_74999,"Household Income $50,000–$74,999","Estimated households with income of $50,000 to $74,999 (including benefits, adjusted for inflation to survey end year)",integer,false,households,public_household_income.csv
+e_household_inc_75000_99999,"Household Income $75,000–$99,999","Estimated households with income of $75,000 to $99,999 (including benefits, adjusted for inflation to survey end year)",integer,false,households,public_household_income.csv
+e_household_inc_under_10000,Household Income Under $10k,"Estimated households with income under $10,000 (including benefits, adjusted for inflation to survey end year)",integer,false,households,public_household_income.csv
+e_household_median_income,Median Household Income,"Estimated median household income (including benefits, adjusted for inflation to survey end year)",integer,true,USD,public_household_income.csv
+e_households_total,Total Households,Estimated total number of households,integer,false,households,public_household_income.csv
 economic_region,DCRA Economic Region,Alaska Division of Community and Regional Affairs (DCRA) economic regions were determined based on 2013 borough and census area geography by the Alaska Department of Labor & Workforce Development.,string,TRUE,null,default
 eia_plant_id,Energy Information Administration Plant ID,,number,TRUE,null,default
+end_year,ACS End Year,End year (vintage) of the 5-year ACS survey observation window,integer,false,year,public_household_income.csv
 end_year,End Year,End of the data collection period,integer,FALSE,null,default
 entity_name,Entity Name,,string,TRUE,NULL,default
 estimated_pop_age_10_14,Estimated Population 10-14 Years Old,Estimated population between ages 10-14 years old,number,TRUE,null,default
@@ -130,6 +143,7 @@ service_area_net_generation_mwh,Service Area Net Generation (MWh),Net generation
 service_area_pce_fuel_price,Service Area PCE Fuel Price,Price of fuel paid by utility as reported to PCE program,number,TRUE,USD,default
 source,Source of Fuel Price Data,"Name of reporting entity if surveyed, or DCRA if regionally averaged",string,TRUE,null,public_fuel_prices.csv
 source,Source,Source of data,string,TRUE,null,default
+start_year,ACS Start Year,Start year of the 5-year ACS survey observation window,integer,false,year,public_household_income.csv
 start_year,Start Year,Beginning of the data collection period,integer,FALSE,null,default
 state_ferry,State Ferry,"Answers the question: Is the Community served by a state ferry? (""t"" for yes, and ""f"" for no)",boolean,TRUE,null,default
 tank_farm_evaluation_id,Tank Farm Evaluation ID,,string,TRUE,NULL,default

--- a/src/generate_metadata.yml
+++ b/src/generate_metadata.yml
@@ -124,3 +124,7 @@ datasets:
     data_path: data/public/public_service_areas/public_service_areas.geojson
     bbox: infer
     time: specify
+  public_household_income:
+    data_path: data/public/public_household_income/public_household_income.csv
+    bbox: infer
+    time: specify


### PR DESCRIPTION
Resolves [AEDG-795](https://projects.camio.acep.uaf.edu/cyberinfrastructure/browse/AEDG-795/)

- Creates metadata for `public_household_income`
- Adds new **income** and **population** keywords

Let me know if you think I should remove the inflation adjusted and includes benefits parts from the field descriptions. It's also in the description.